### PR TITLE
feat: add photo article pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,10 @@ async function loadEntries() {
 }
 
 /**
- * Loads photos from the images directory.
+ * Loads photos from the images directory and links each one to
+ * its dedicated article page.
+ *
+ * @returns {void}
  */
 function loadPhotos() {
   const container = document.getElementById("photos");
@@ -27,10 +30,13 @@ function loadPhotos() {
     "images/journal-photo4.jpeg",
     "images/journal-photo5.jpeg",
   ];
-  photos.forEach((src) => {
+  photos.forEach((src, idx) => {
+    const link = document.createElement("a");
+    link.href = `docs/photo${idx + 1}.html`;
     const img = document.createElement("img");
     img.src = src;
-    container.appendChild(img);
+    link.appendChild(img);
+    container.appendChild(link);
   });
 }
 

--- a/docs/photo1.html
+++ b/docs/photo1.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Photo 1</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="../index.html">Back to Journal</a>
+      <a href="photo2.html">Next</a>
+    </nav>
+    <h1>Sunlit Forest Trail</h1>
+    <img src="../images/journal-photo1.jpeg" alt="Forest path" />
+    <article>
+      <p>
+        This image captures a serene woodland path with rays of sunlight
+        filtering through the trees. It invites the viewer to take a peaceful
+        walk in nature.
+      </p>
+    </article>
+  </body>
+</html>

--- a/docs/photo2.html
+++ b/docs/photo2.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Photo 2</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="photo1.html">Previous</a>
+      <a href="photo3.html">Next</a>
+    </nav>
+    <h1>Mountain Lake at Dusk</h1>
+    <img src="../images/journal-photo2.jpeg" alt="Mountain lake" />
+    <article>
+      <p>
+        Calm waters reflect the fading light over distant mountains. This scene
+        illustrates the tranquility of evening by a high-altitude lake.
+      </p>
+    </article>
+  </body>
+</html>

--- a/docs/photo3.html
+++ b/docs/photo3.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Photo 3</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="photo2.html">Previous</a>
+      <a href="photo4.html">Next</a>
+    </nav>
+    <h1>City Skyline</h1>
+    <img src="../images/journal-photo3.jpeg" alt="City skyline" />
+    <article>
+      <p>
+        Tall buildings rise against a vibrant sunset. The photo captures the
+        energy of city life as day transitions into night.
+      </p>
+    </article>
+  </body>
+</html>

--- a/docs/photo4.html
+++ b/docs/photo4.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Photo 4</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="photo3.html">Previous</a>
+      <a href="photo5.html">Next</a>
+    </nav>
+    <h1>Desert Road</h1>
+    <img src="../images/journal-photo4.jpeg" alt="Desert road" />
+    <article>
+      <p>
+        Endless sands flank a solitary road stretching toward the horizon,
+        evoking a sense of adventure and isolation.
+      </p>
+    </article>
+  </body>
+</html>

--- a/docs/photo5.html
+++ b/docs/photo5.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Photo 5</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <nav>
+      <a href="photo4.html">Previous</a>
+      <a href="../index.html">Back to Journal</a>
+    </nav>
+    <h1>Coastal Sunrise</h1>
+    <img src="../images/journal-photo5.jpeg" alt="Coastal sunrise" />
+    <article>
+      <p>
+        Waves lap gently against the shore as the sun rises, casting warm
+        colours over the ocean. The picture captures the start of a new day.
+      </p>
+    </article>
+  </body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,97 +1,30 @@
-/**
- * Retrieve a query parameter from the URL.
- * @param {string} name - Parameter name.
- * @returns {string|null} The parameter value or null.
- */
-function getParam(name) {
-  return new URLSearchParams(window.location.search).get(name);
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
 }
 
-/**
- * Load a conversation by index and display it.
- * @param {number} idx - Conversation index.
- * @returns {void}
- */
-function loadConversation(idx) {
-  const images = [
-    "../images/file-72jQ6thojeuUeE7Kd8A1t7-IMG_2ACDECCE-CF79-481B-8AD6-AC6C6C6F27FB.jpeg",
-    "../images/file-9e9vEQGrqMMNm9nYDzmaUt-IMG_DE34B664-8B17-46BA-9904-7B218C7A664C.jpeg",
-    "../images/file-ASTUeW6XAHMhQjcH8pDWzW-IMG_064B4BE5-EC7C-480C-982E-368A5D9E1681.jpeg",
-    "../images/file-CjjdBdQLaPwkmeBer68Ga2-IMG_D4A12851-2AFD-4571-9EE0-0A7AE0A2E8C5.jpeg",
-  ];
-
-  fetch("../data/conversations.json")
-    .then((resp) => resp.json())
-    .then((convos) => {
-      const convo = convos[idx];
-      if (!convo) {
-        alert("Conversation not found.");
-        return;
-      }
-      const titleElem = document.getElementById("title");
-      if (titleElem) titleElem.textContent = convo.title || "Conversation";
-      const container = document.getElementById("conversation");
-      if (container) {
-        const messages = Object.values(convo.mapping);
-        messages.sort((a, b) => a.message.create_time - b.message.create_time);
-        container.textContent = messages
-          .map(
-            (m) =>
-              `${m.message.author.role}: ${m.message.content.parts.join("\n")}`,
-          )
-          .join("\n\n");
-      }
-      const imgElem = document.getElementById("topicImage");
-      if (imgElem) imgElem.src = images[idx % images.length];
-      handleNavigation(idx, convos.length);
-      loadNotes(idx);
-    });
+h1 {
+  text-align: center;
 }
 
-/**
- * Load and save notes for a given topic.
- * @param {number} idx - Conversation index.
- * @returns {void}
- */
-function loadNotes(idx) {
-  const noteKey = `note_${idx}`;
-  const noteArea = document.getElementById("noteArea");
-  if (!noteArea) return;
-  noteArea.value = localStorage.getItem(noteKey) || "";
-  const saveBtn = document.getElementById("saveNote");
-  if (saveBtn) {
-    saveBtn.onclick = () => {
-      localStorage.setItem(noteKey, noteArea.value);
-      alert("Note saved");
-    };
-  }
+#entry-list {
+  list-style: none;
+  padding: 0;
 }
 
-/**
- * Enable previous/next buttons for navigation.
- * @param {number} idx - Current conversation index.
- * @param {number} count - Total conversations.
- * @returns {void}
- */
-function handleNavigation(idx, count) {
-  const prev = document.getElementById("prevTopic");
-  const next = document.getElementById("nextTopic");
-  if (prev) {
-    prev.disabled = idx <= 0;
-    prev.onclick = () => {
-      if (idx > 0) window.location.href = `topic.html?id=${idx - 1}`;
-    };
-  }
-  if (next) {
-    next.disabled = idx >= count - 1;
-    next.onclick = () => {
-      if (idx < count - 1) window.location.href = `topic.html?id=${idx + 1}`;
-    };
-  }
+.entry {
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  let id = parseInt(getParam("id"), 10);
-  if (isNaN(id)) id = 0;
-  loadConversation(id);
-});
+#photos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+#photos img {
+  max-width: 200px;
+  height: auto;
+  border: 1px solid #eee;
+}


### PR DESCRIPTION
## Summary
- add individual photo pages with articles and navigation
- link gallery images to new pages
- replace incorrect JS in `docs/style.css` with real CSS styles

## Testing
- `npm ci`
- `coverage run -m pytest`
- `coverage html && coverage report`
- `npx eslint docs --fix`
- `npx prettier --check "docs/**/*.{js,html,css}"`
- `mypy .`
- `npm audit --omit=dev`
- `bandit -r .`


------
https://chatgpt.com/codex/tasks/task_e_6842cb5e81508330bd6716eaaad46b52